### PR TITLE
Add Exa Search integration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -135,18 +135,24 @@ Enable `file-system` to allow Athena to access your local file system. Athena wi
 
 ### HTTP
 
-Enable `http` for Athena to send HTTP requests, search the web via Jina Search, and download files from the Internet.
+Enable `http` for Athena to send HTTP requests, search the web via Jina Search or Exa Search, and download files from the Internet.
 
 ```yaml
   http:
-    jina:
+    jina: # Optional Jina config
       base_url: https://s.jina.ai
       api_key: your-jina-api-key
+    exa: # Optional Exa config
+      base_url: https://api.exa.ai # Optional, defaults to this
+      api_key: your-exa-api-key   # Required if using Exa
 ```
 
 - `jina`: Configuration for [Jina Search](https://jina.ai/). (Optional)
-  - `base_url`: The base URL of the Jina Search API endpoint.
-  - `api_key`: The API key for the Jina Search API endpoint.
+  - `base_url`: The base URL of the Jina Search API endpoint. (Optional, defaults to `https://s.jina.ai`)
+  - `api_key`: The API key for the Jina Search API endpoint. (Required if using Jina)
+- `exa`: Configuration for [Exa Search](https://exa.ai/). (Optional)
+  - `base_url`: The base URL of the Exa Search API endpoint. (Optional, defaults to `https://api.exa.ai`)
+  - `api_key`: The API key for the Exa Search API endpoint. (Required if using Exa)
 
 ### LLM
 

--- a/src/plugins/http/exa.ts
+++ b/src/plugins/http/exa.ts
@@ -1,0 +1,55 @@
+export interface IExaSearchInitParams {
+  baseUrl?: string;
+  apiKey: string;
+}
+
+export interface IExaSearchResult {
+  title: string;
+  url: string;
+  text: string; // Text content from the search result
+}
+
+export class ExaSearch {
+  baseUrl: string;
+  apiKey: string;
+
+  constructor(initParams: IExaSearchInitParams) {
+    // Default Exa API endpoint
+    this.baseUrl = initParams.baseUrl || "https://api.exa.ai";
+    this.apiKey = initParams.apiKey;
+  }
+
+  async search(query: string): Promise<IExaSearchResult[]> {
+    const response = await fetch(`${this.baseUrl}/search`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": this.apiKey, // Exa uses x-api-key header
+        Accept: "application/json", // Ensure we get JSON back
+      },
+      // Request body structure based on the curl example
+      body: JSON.stringify({
+        query: query,
+        contents: {
+          text: { maxCharacters: 1000 }, // Request text snippets
+        },
+        numResults: 10, // Request 10 results, adjust as needed
+      }),
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      console.error("Exa API Error:", response.status, errorBody);
+      throw new Error(`Failed to search with Exa API: ${response.statusText}`);
+    }
+
+    const json = await response.json();
+    // Map the response structure to IExaSearchResult
+    // Adjust based on actual Exa response format if different
+    return json.results.map((result: any) => ({
+      title: result.title || "No Title", // Provide default if title is missing
+      url: result.url,
+      text: result.text || "No text content", // Extract text from contents if available
+    }));
+  }
+}


### PR DESCRIPTION
- Introduced a new ExaSearch class for handling searches via the Exa API, including methods for initialization and search functionality.
- Updated the HTTP plugin to support Exa Search, allowing users to configure and utilize Exa API for web searches.
- Enhanced the configuration documentation to include details about Exa Search, including optional parameters for base URL and API key.

This commit enhances the functionality of the HTTP plugin by integrating Exa Search, providing users with additional search capabilities.